### PR TITLE
fix spp-common mismatch in after explode0

### DIFF
--- a/complete_r_script.R
+++ b/complete_r_script.R
@@ -7,7 +7,7 @@
 #   3) Manually change the WORKING_DIRECTORY variable (line 27) to the directory with your data and run the script. 
 
 # RDB quality of life enhancer "~/Documents/School&Work/pinskyPost/OceanAdapt/data_download/Data_Vis_2015_09_04"
-# setwd("/Users/Battrd/Documents/School&Work/pinskyPost/OceanAdapt/data_updates/Data_Updated")
+# setwd("/Users/Battrd/Documents/School&Work/pinskyPost/OceanAdapt/data_updates/")
        
  
 ### File Structure
@@ -1287,6 +1287,8 @@ print_status('>Species data complete.')
 # ===========
 # = Add 0's =
 # ===========
+td_factorColumns <- sapply(trimmed_dat, is.factor)
+trimmed_dat[,td_factorColumns] <- lapply(trimmed_dat[,td_factorColumns], as.character)
 dat.exploded <- as.data.table(trimmed_dat)[,explode0(.SD), by="region"]
 # write.csv(dat.exploded, file.path(WORKING_DIRECTORY, "..", "..", "dat.exploded.csv")) # this will be ~600MB
 


### PR DESCRIPTION
just switched all factors to characters; not sure why this was causing the problem. Debugging showed that each region was being properly "exploded", so the problem was when data.table was recombining the output of explod0 from each region

---

@danfarns Dan, I originally fixed this problem on the update2016 branch, not on master. I hope this did not prevent you from finding my correction.